### PR TITLE
[CL-001] 問い合わせフォームの摩擦除去（successMessage制御/required/reset）

### DIFF
--- a/20_measurement/measurement_plan.md
+++ b/20_measurement/measurement_plan.md
@@ -10,7 +10,7 @@
   - cta_click（CTAクリック）
   - phone_tap（電話タップ）
   - download_brochure（資料DL ※ある場合）
-- Last Updated: 2026-03-14
+- Last Updated: 2026-03-15
 - Owner: Tracking & Measurement Specialist
 - Approver (Production publish): Yuki Isomura
 
@@ -74,12 +74,9 @@
 - Download page: TBD
 - generate_lead は同一ページ内の成功メッセージ `#successMessage` を Element Visibility で検知する方針に確定。
 Trigger は Once per page + Observe DOM changes を採用。
-generate_lead の初回実装完了。
-contact.html の送信成功時に GA4 へ直接 `generate_lead` を送信する方式で実装。
-送信成功UI表示と同時に以下パラメータで発火確認：
-- form_id = contact_main
-- lead_type = inquiry
-- page_path = window.location.pathname
+generate_lead の実装方針を確定。
+- contact.html 側では「送信成功UI（#successMessage）」の表示のみを行う
+- generate_lead は GTM の Element Visibility（#successMessage）で検知して発火（誤認発火防止のため、フォームJSからの直接送信はしない）
 - cta_click の初回実装を追加。
 [data-cta] 属性を持つ主要CTAクリック時に GA4 へ `cta_click` を直接送信。
 送信パラメータ：
@@ -97,7 +94,7 @@ contactForm 内の input / textarea / select へ初回フォーカス時に GA4 
 ## 5. Event Table
 | Event Name | Type | Trigger (preferred / fallback) | URL/Page | Parameters | Priority | Status |
 |---|---|---|---|---|---|---|
-| generate_lead | Primary CV | success UI / thankyou page_view | Form/Thankyou | form_id, page_path, lead_type | High | Planned |
+| generate_lead | Primary CV | success UI / thankyou page_view | Form/Thankyou | form_id, page_path, lead_type | High | Implemented |
 | form_start | Secondary CV | form visible / form page_view | Form | form_id, page_path | Medium | Planned |
 | cta_click | Secondary CV | CTA click | Any | cta_text, cta_location, page_path | Medium | Planned |
 | phone_tap | Secondary CV | tel: click | Any | phone_number, page_path | Medium | Planned |

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,359 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-PNCBBCBM');</script>
+  <!-- End Google Tag Manager -->
+
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Football Hub Japanへのお問い合わせページ。ご質問、ご意見、ご要望をお気軽にお寄せください。" />
+  <meta name="keywords" content="お問い合わせ,連絡先,サポート" />
+  <meta property="og:title" content="お問い合わせ - Football Hub Japan" />
+  <meta property="og:description" content="Football Hub Japanへのお問い合わせページ。ご質問、ご意見、ご要望をお気軽にお寄せください。" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://football-hub-japan-ubzb.onrender.com/contact.html" />
+  <meta name="robots" content="index,follow" />
+
+  <title>お問い合わせ - Football Hub Japan</title>
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-47242CTHR5"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-47242CTHR5');
+  </script>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --background: #0d1117;
+      --foreground: #f0f6fc;
+      --card: #161b22;
+      --primary: #22c55e;
+      --primary-hover: #16a34a;
+      --muted: #8b949e;
+      --border: #30363d;
+      --border-light: rgba(48, 54, 61, 0.5);
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'Noto Sans JP', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: var(--background);
+      color: var(--foreground);
+      line-height: 1.8;
+      min-height: 100vh;
+    }
+
+    .header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: rgba(13, 17, 23, 0.8);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border-light);
+    }
+
+    .header-container {
+      max-width: 1280px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0 1.5rem;
+      height: 64px;
+    }
+
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-decoration: none;
+      color: var(--foreground);
+    }
+
+    .logo-icon {
+      width: 32px;
+      height: 32px;
+      background: var(--primary);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.1rem;
+    }
+
+    .logo-text {
+      font-size: 1.125rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .nav-menu {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      list-style: none;
+    }
+
+    .nav-menu a {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: color 0.2s;
+    }
+
+    .nav-menu a:hover { color: var(--foreground); }
+
+    .btn {
+      padding: 0.5rem 1rem;
+      border-radius: 8px;
+      font-size: 0.875rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: var(--background);
+      border: none;
+    }
+
+    .btn-primary:hover { background: var(--primary-hover); }
+
+    .content {
+      max-width: 700px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem;
+    }
+
+    .content h1 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      letter-spacing: -0.02em;
+    }
+
+    .content p { margin-bottom: 1.5rem; color: var(--muted); }
+
+    .form-group { margin-bottom: 1.5rem; }
+
+    .form-label {
+      display: block;
+      margin-bottom: 0.5rem;
+      font-weight: 500;
+      color: var(--foreground);
+    }
+
+    .form-input,
+    .form-textarea {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--foreground);
+      font-family: inherit;
+      font-size: 0.9375rem;
+      transition: border-color 0.2s;
+    }
+
+    .form-input:focus,
+    .form-textarea:focus {
+      outline: none;
+      border-color: var(--primary);
+    }
+
+    .form-textarea { min-height: 150px; resize: vertical; }
+
+    .form-submit {
+      width: 100%;
+      padding: 0.875rem 1.5rem;
+      background: var(--primary);
+      color: var(--background);
+      border: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .form-submit:hover { background: var(--primary-hover); }
+
+    .form-note {
+      margin-top: 1rem;
+      padding: 1rem;
+      background: rgba(34, 197, 94, 0.1);
+      border: 1px solid rgba(34, 197, 94, 0.3);
+      border-radius: 8px;
+      font-size: 0.875rem;
+      color: var(--muted);
+      line-height: 1.6;
+    }
+
+    /* 初期状態で successMessage が表示されないようにする */
+    .success-message {
+      display: none;
+      margin-top: 1.5rem;
+      padding: 1.5rem;
+      background: rgba(34, 197, 94, 0.1);
+      border: 1px solid rgba(34, 197, 94, 0.3);
+      border-radius: 8px;
+      color: var(--primary);
+      text-align: center;
+    }
+
+    .success-message.show { display: block; }
+
+    .mailto-link {
+      margin-top: 2rem;
+      padding-top: 2rem;
+      border-top: 1px solid var(--border);
+      text-align: center;
+    }
+
+    .mailto-link a { color: var(--primary); text-decoration: none; }
+    .mailto-link a:hover { text-decoration: underline; }
+
+    @media (max-width: 768px) {
+      .nav-menu { display: none; }
+      .content h1 { font-size: 2rem; }
+    }
+  </style>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PNCBBCBM" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <header class="header">
+    <div class="header-container">
+      <a href="/" class="logo">
+        <div class="logo-icon">⚡</div>
+        <span class="logo-text">Football Hub Japan</span>
+      </a>
+
+      <ul class="nav-menu">
+        <li><a href="/database-new.html">データベース</a></li>
+        <li><a href="/radar-enhanced.html">レーダーチャート</a></li>
+        <li><a href="/schedule.html">スケジュール</a></li>
+        <li><a href="/ai-agent-enhanced.html">AI分析</a></li>
+        <li><a href="/ranking.html">ランキング</a></li>
+        <li><a href="/insights.html">分析コラム</a></li>
+      </ul>
+
+      <div class="header-buttons">
+        <a href="/dashboard.html" class="btn btn-primary" data-cta="contact" data-cta-location="header">無料で始める</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <div class="content">
+      <h1>お問い合わせ</h1>
+      <p>ご質問、ご意見、ご要望がございましたら、以下のフォームよりお気軽にお問い合わせください。お返事には数日かかる場合がございますので、あらかじめご了承ください。</p>
+
+      <form id="contactForm" onsubmit="handleSubmit(event)">
+        <div class="form-group">
+          <label for="name" class="form-label">お名前 <span style="color: var(--muted);">（任意）</span></label>
+          <input type="text" id="name" name="name" class="form-input" placeholder="山田 太郎" />
+        </div>
+
+        <div class="form-group">
+          <label for="email" class="form-label">メールアドレス <span style="color: var(--primary);">（必須）</span></label>
+          <input type="email" id="email" name="email" class="form-input" placeholder="example@email.com" required />
+        </div>
+
+        <div class="form-group">
+          <label for="subject" class="form-label">件名 <span style="color: var(--muted);">（任意）</span></label>
+          <input type="text" id="subject" name="subject" class="form-input" placeholder="お問い合わせの件名" />
+        </div>
+
+        <div class="form-group">
+          <label for="message" class="form-label">メッセージ <span style="color: var(--primary);">（必須）</span></label>
+          <textarea id="message" name="message" class="form-textarea" placeholder="お問い合わせ内容をご記入ください" required></textarea>
+        </div>
+
+        <button type="submit" class="form-submit">送信する</button>
+      </form>
+
+      <div id="successMessage" class="success-message">
+        お問い合わせありがとうございます。
+      </div>
+
+      <div class="form-note">
+        <p><strong>ご注意:</strong> 自動送信やスパム行為はお控えください。また、現時点ではフォーム送信はフロントエンドのみで動作しており、実際のメール送信機能は実装されていません。緊急のご連絡が必要な場合は、下記のメールアドレスをご利用ください。</p>
+      </div>
+
+      <div class="mailto-link">
+        <p>メールでのお問い合わせ: <a href="mailto:contact@footballhubjapan.com">contact@footballhubjapan.com</a></p>
+      </div>
+    </div>
+  </main>
+
+  <script>
+    function handleSubmit(event) {
+      event.preventDefault();
+
+      const form = document.getElementById('contactForm');
+      const successMessage = document.getElementById('successMessage');
+
+      // 成功メッセージは初期表示しない（念のため、送信前にも隠す）
+      if (successMessage) {
+        successMessage.classList.remove('show');
+      }
+
+      // required 等のブラウザ標準バリデーションを通過した場合のみ「成功」とみなす
+      if (form && !form.checkValidity()) {
+        form.reportValidity();
+        return false;
+      }
+
+      // 送信成功時のみ successMessage を表示
+      if (successMessage) {
+        successMessage.classList.add('show');
+      }
+
+      // generate_lead は「#successMessage の表示」をGTM側で検知する（誤認発火防止のため、ここでは送らない）
+
+      // 送信後にフォームを reset
+      if (form) {
+        form.reset();
+      }
+
+      return false;
+    }
+  </script>
+
+  <script>
+    // 念のため: 初期ロード時に successMessage を常に非表示
+    document.addEventListener('DOMContentLoaded', function () {
+      const successMessage = document.getElementById('successMessage');
+      if (successMessage) {
+        successMessage.classList.remove('show');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #7

## 変更内容
- contact.html: successMessage を初期表示しない / 送信成功時のみ表示 / 送信後にフォームreset
- contact.html: email / message を required に（既存属性を維持）
- contact.html: generate_lead のJS直接送信を停止（誤認発火防止。GTM側の Element Visibility (#successMessage) 検知に寄せる）
- measurement_plan.md: 上記方針を反映し、generate_lead を Implemented に更新

## 確認
- ローカル http://127.0.0.1:5173/contact.html で確認
  - 初期表示で successMessage 非表示
  - 空のまま送信するとブラウザ標準バリデーションが出る（required）
  - email+message入力→送信で successMessage 表示 + email/message が空になる（reset）

## 未確認
- GTM Preview / GA4 DebugView での generate_lead 発火（Publishは未実施）
- Render 本番導線での表示確認
